### PR TITLE
CT-32/CT-106

### DIFF
--- a/.docker/localstack/entrypoint.sh
+++ b/.docker/localstack/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-awslocal s3api create-bucket --bucket profile-images
+awslocal s3api create-bucket --bucket $STORAGE_BUCKET

--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,8 @@ POSTGRES_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${POST
 # Google Maps
 GOOGLE_MAPS_API_KEY= #Chave de acesso do Google Maps
 
-#AWS S3
-S3_ENDPOINT="http://s3.localhost.localstack.cloud:4566" #Endpoint do S3
-S3_REGION="us-east-1"                                   #Região do S3
-S3_ACCESS_KEY_ID="default"                              #Chave de acesso do S3
-S3_SECRET_ACCESS_KEY="default"                          #Chave secreta do S3
+# Object Storage
+STORAGE_ENDPOINT="http://s3.localhost.localstack.cloud:4566" # Endpoint
+STORAGE_REGION="us-east-1"                                   # Região
+STORAGE_ACCESS_KEY_ID="default"                              # Chave de acesso
+STORAGE_SECRET_ACCESS_KEY="default"                          # Chave secreta

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ GOOGLE_MAPS_API_KEY= #Chave de acesso do Google Maps
 
 # Object Storage
 STORAGE_ENDPOINT="http://s3.localhost.localstack.cloud:4566" # Endpoint
+STORAGE_BUCKET="connectattoo"                                # Bucket
 STORAGE_REGION="us-east-1"                                   # Região
 STORAGE_ACCESS_KEY_ID="default"                              # Chave de acesso
 STORAGE_SECRET_ACCESS_KEY="default"                          # Chave secreta

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV NODE_ENV production
 
 RUN npm ci --only=production && npm cache clean --force
 
+RUN npx prisma generate
+
 RUN npm run build
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /api
 
 RUN git clone --recurse-submodules https://github.com/connectattoo/connectattoo.backend .
 
-COPY --chown=node:node --chmod=755 tsconfig.json package*.json nest-cli.json .gitmodules ./
+COPY --chmod=755 tsconfig.json package*.json nest-cli.json .gitmodules ./
 
-COPY --chown=node:node --chmod=755 /src ./src
+COPY --chmod=755 /src ./src
 
 ENV NODE_ENV production
 
@@ -22,10 +22,10 @@ FROM node:18-alpine AS production
 
 WORKDIR /api
 
-COPY --chown=root:root --chmod=755 --from=build /api/node_modules ./node_modules
+COPY --from=build /api/node_modules ./node_modules
 
-COPY --chown=root:root --chmod=755 --from=build /api/dist ./dist
+COPY --from=build /api/dist ./dist
 
-COPY --chown=root:root --chmod=755 --from=build /api/prisma ./prisma
+COPY --from=build /api/prisma ./prisma
 
 CMD ["/bin/sh", "-c", "npx prisma migrate deploy;node dist/shared/adapters/prisma/seeds/index.js;node dist/main.js"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,11 +63,11 @@ services:
     container_name: localstack
     image: localstack/localstack
     ports:
-      - "4566:4566"
+      - 4566:4566
     environment:
       - SERVICES=s3
     volumes:
-      - "./.docker/localstack/entrypoint.sh:/etc/localstack/init/ready.d/entrypoint.sh"
+      - ./.docker/localstack/entrypoint.sh:/etc/localstack/init/ready.d/entrypoint.sh
     networks:
       - connectattoo
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,6 +66,8 @@ services:
       - 4566:4566
     environment:
       - SERVICES=s3
+    env_file:
+      - .env
     volumes:
       - ./.docker/localstack/entrypoint.sh:/etc/localstack/init/ready.d/entrypoint.sh
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       - 4566:4566
     environment:
       - SERVICES=s3
+    env_file:
+      - .env
     volumes:
       - ./.docker/localstack/entrypoint.sh:/etc/localstack/init/ready.d/entrypoint.sh
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,18 @@ services:
       timeout: 5s
       retries: 5
 
+  localstack:
+    container_name: localstack
+    image: localstack/localstack
+    ports:
+      - 4566:4566
+    environment:
+      - SERVICES=s3
+    volumes:
+      - ./.docker/localstack/entrypoint.sh:/etc/localstack/init/ready.d/entrypoint.sh
+    networks:
+      - connectattoo
+
 networks:
   connectattoo:
     name: connectattoo


### PR DESCRIPTION
# Alterar configurações de ambiente e ferramentas
* Renomeadas todas as variáveis com `S3` para `STORAGE` para adequação.
* Adicionada variável `STORAGE_BUCKT` com valor "connectattoo" ao arquivo `.env.exemple` e `entrypoint.sh`. Agora é necessário somente alterar o nome do bucket no arquivo de variáveis.
* Removidas as atribuições de dono de `root` e `node` nos arquivos do container para "passar" no SonarQube.
* Adicionado LocalStack ao arquivo `docker-compose.yml` para testes de upload.